### PR TITLE
Compare active route to current route on _renderIcon

### DIFF
--- a/src/navigators/createMaterialBottomTabNavigator.js
+++ b/src/navigators/createMaterialBottomTabNavigator.js
@@ -27,9 +27,17 @@ class BottomNavigationView extends React.Component<Props> {
   }
 
   _renderIcon = ({ route, focused, color }) => {
-    const { navigation: { state } } = this.props
+    const { 
+      navigation: { state },
+      activeColor,
+      inactiveColor 
+    } = this.props
     const activeRoute = state.routes[state.index].key;
-    return this.props.renderIcon({ route, focused: activeRoute === route.key, tintColor: color });
+    return this.props.renderIcon({ 
+      route, 
+      focused: activeRoute === route.key, 
+      tintColor: activeRoute === route.key ? activeColor : inactiveColor
+    });
   };
 
   render() {

--- a/src/navigators/createMaterialBottomTabNavigator.js
+++ b/src/navigators/createMaterialBottomTabNavigator.js
@@ -27,7 +27,9 @@ class BottomNavigationView extends React.Component<Props> {
   }
 
   _renderIcon = ({ route, focused, color }) => {
-    return this.props.renderIcon({ route, focused, tintColor: color });
+    const { navigation: { state } } = this.props
+    const activeRoute = state.routes[state.index].key;
+    return this.props.renderIcon({ route, focused: activeRoute === route.key, tintColor: color });
   };
 
   render() {


### PR DESCRIPTION
This is a  fix for the `focused` state that is passed to `this.props.renderIcon`.  The issue lies within the following chunk of code inside `react-native-paper/BottomNavigation`.

```
 <Animated.View
           style={[styles.iconWrapper, { opacity: activeOpacity }]}
                      >
                        {renderIcon ? (
                          renderIcon({
                            route,
                            focused: true,
                            color: activeTintColor,
                          })
                        ) : (
                          <Icon
                            source={(route: Object).icon}
                            color={activeTintColor}
                            size={24}
                          />
                        )}
                      </Animated.View>
                      <Animated.View
                        style={[
                          styles.iconWrapper,
                          { opacity: inactiveOpacity },
                        ]}
                      >
                        {renderIcon ? (
                          renderIcon({
                            route,
                            focused: false,
                            color: inactiveTintColor,
                          })
                        ) : (
                          <Icon
                            source={(route: Object).icon}
                            color={inactiveTintColor}
                            size={24}
                          />
                        )}
                      </Animated.View>
```

This code lives inside a `routes.map` function.  When a user presses a tabIcon, it rerenders causing the routes.map to run for every route and sending focused state `true` then `false` for every Icon.  I don't know enough about react-native-papers intention in doing this, so I'm not sure if this problem should be discussed with you or them.  Would love to hear your thoughts.  Thanks again, I love how elegant the transitions are with this, so smooth!